### PR TITLE
Update compile_su3_rhmd_hisq_quda to reflect recent changes to Makefile

### DIFF
--- a/ks_imp_rhmc/compile_su3_rhmd_hisq_quda.sh
+++ b/ks_imp_rhmc/compile_su3_rhmd_hisq_quda.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-MY_CC=mpicc \
-MY_CXX=mpicxx \
+CC=mpicc \
+CXX=mpicxx \
 CUDA_HOME=${PATH_TO_CUDA} \
 QUDA_HOME=${PATH_TO_QUDA} \
 WANTQUDA=true \


### PR DESCRIPTION
Recent changes in the MILC `Makefile` made the variables `CC` and `CXX` easy to override from the command line, as opposed to setting `MY_CC` and `MY_CXX`, which seems to have become more fragile. This PR updates the RHMC compile helper script to reflect this change. 